### PR TITLE
fix: add client ID to status messages

### DIFF
--- a/src/ISurroundChannelsMessenger.cs
+++ b/src/ISurroundChannelsMessenger.cs
@@ -1,13 +1,8 @@
-﻿using Newtonsoft.Json;
-using PepperDash.Core;
+﻿using PepperDash.Core;
 using PepperDash.Essentials.AppServer.Messengers;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using Crestron.SimplSharp;
 using PepperDash.Essentials.AppServer;
 using PepperDash.Essentials.Core;
 
@@ -28,7 +23,7 @@ namespace PDT.Plugins.Marantz
 
             AddAction("/fullStatus", (id, content) =>
             {
-                SendFullStatus();
+                SendFullStatus(id);
             });
 
             AddAction("/setDefaultChannelLevels", (id, content) =>
@@ -42,33 +37,18 @@ namespace PDT.Plugins.Marantz
             _surroundDevice.SurroundChannelsUpdated += (sender, args) =>
             {
                 RegisterChannels();
-                SendFullStatus();
-
-                //if (_updateTimer != null)
-                //{
-                //    _updateTimer.Reset();
-                //    return;
-                //}
-                //else
-                //{
-                //    _updateTimer = new CTimer(o =>
-                //    {
-                //        RegisterChannels();
-                //        Debug.Console(2, this, "*********Surround channels updated, sending full status*********");
-                //        SendFullStatus();
-                //    }, 1000);
-                //}
+                SendFullStatus();                
             };
         }
 
-        private void SendFullStatus()
+        private void SendFullStatus(string id = null)
         {
             var message = new LevelControlStateMessage
             {
                 Levels = GetVolumeLevels()
             };
               
-            PostStatusMessage(message);
+            PostStatusMessage(message, id);
         }
 
         private void RegisterChannels()


### PR DESCRIPTION
This pull request refactors the `ISurroundChannelsMessenger` class to improve how status messages are sent and to clean up unused code. The main change is updating the `SendFullStatus` method to accept an optional `id` parameter, allowing status messages to be associated with a specific request. Additionally, some unused code and redundant using directives have been removed for clarity.

**Refactoring and API improvements:**

* Updated the `SendFullStatus` method in `ISurroundChannelsMessenger.cs` to accept an optional `id` parameter and pass it to `PostStatusMessage`, enabling responses to be tied to specific requests.
* Modified the `/fullStatus` action registration to pass the `id` parameter to `SendFullStatus`.

**Code cleanup:**

* Removed unused using directives from the top of `ISurroundChannelsMessenger.cs` for improved readability.
* Deleted commented-out timer code from the channel registration handler to reduce clutter.