### PR TITLE
fix: SurroundModesMessenger uses base device key

### DIFF
--- a/src/MarantzDevice.cs
+++ b/src/MarantzDevice.cs
@@ -244,10 +244,10 @@ namespace PDT.Plugins.Marantz
                 return;
             }
 
-            var surroundModeMessenger = new SurroundModesMessenger<SurroundModes>
+            var surroundModeMessenger = new SurroundModesMessenger<SurroundModes, string>
                 ($"{Key}-surroundSoundModes-plugin",
                 $"/device/{Key}",
-                SurroundSoundModes);
+                this);
 
             mc.AddDeviceMessenger(surroundModeMessenger);
 

--- a/src/SurroundModesMessenger.cs
+++ b/src/SurroundModesMessenger.cs
@@ -9,12 +9,13 @@ using System.Collections.Generic;
 
 namespace PDT.Plugins.Marantz
 {
-    public class SurroundModesMessenger<TKey> : MessengerBase
+    public class SurroundModesMessenger<TKey, TSelector> : MessengerBase
     {
         private readonly ISelectableItems<TKey> device;
-        public SurroundModesMessenger(string key, string messagePath, ISelectableItems<TKey> device) : base(key, messagePath, device as IKeyName)
+
+        public SurroundModesMessenger(string key, string messagePath, IHasSurroundSoundModes<TKey, TSelector> device) : base(key, messagePath, device as IKeyName)
         {
-            this.device = device;
+            this.device = device.SurroundSoundModes;
         }
         
         protected override void RegisterActions()


### PR DESCRIPTION
Because of the way the surround modes messenger was built,
it was using the key of the parent device in the path, eg /device/avr,
but the key of the ISelectableItems object in the actual messages. This
caused the key of the device to change in the store, which caused cascading issues
in the UI, as the device key was expected to remain as the parent device's key.

This pull request refactors the messenger logic for surround sound modes to improve type safety and better support selector functionality. The main change is updating the `SurroundModesMessenger` class to accept a selector type parameter and use the `IHasSurroundSoundModes` interface, which allows for more flexible and robust handling of surround sound modes.

**Refactoring for improved type safety and selector support:**

* Changed the `SurroundModesMessenger` class to accept two type parameters (`TKey, TSelector`) and now requires an `IHasSurroundSoundModes` implementation, improving flexibility and type safety. (`src/SurroundModesMessenger.cs`, [src/SurroundModesMessenger.csL12-R18](diffhunk://#diff-84c429b646c0c984296cffab9226fddfd5427a4ec3ad4ca8d59b75f2be2e9ed4L12-R18))
* Updated the instantiation of `SurroundModesMessenger` in `MarantzDevice` to use the new type parameters and pass the device instance instead of just the surround sound modes collection. (`src/MarantzDevice.cs`, [src/MarantzDevice.csL247-R250](diffhunk://#diff-5dc13dd44f3d07eee0d852088b3c435540b396255d17c30c54bd94a117e36091L247-R250))
